### PR TITLE
Add config option and command to toggle Man entity spawning

### DIFF
--- a/src/main/java/com/zen/the_fog/common/config/Config.java
+++ b/src/main/java/com/zen/the_fog/common/config/Config.java
@@ -56,6 +56,13 @@ public class Config {
     public boolean spawnChanceScalesWithPlayerCount = false;
 
     @AutoGen(category = "default",group = "spawning")
+    @CustomName("Enable Man Spawning")
+    @CustomDescription("If true, The Man entity will be allowed to spawn. Set to false to disable all Man spawns.")
+    @Boolean(formatter = Boolean.Formatter.YES_NO)
+    @SerialEntry(comment = "If true, The Man entity (and related creepy sounds) will be enabled. Set to false to disable them entirely.")
+    public boolean enableManSpawning = true;
+
+    @AutoGen(category = "default",group = "spawning")
     @DoubleField(min = 1)
     @CustomName("Time between spawn attempts in seconds")
     @SerialEntry(comment = "Time between spawn attempts in seconds")

--- a/src/main/java/com/zen/the_fog/common/server/ModCommands.java
+++ b/src/main/java/com/zen/the_fog/common/server/ModCommands.java
@@ -27,6 +27,14 @@ public class ModCommands {
                     context.getSource().sendFeedback(() -> Text.of("Reloaded"),true);
                     return 1;
                 }))
+                .then(literal("toggleManSpawning").executes(context -> {
+                    Config config = Config.get();
+                    config.enableManSpawning = !config.enableManSpawning;
+                    Config.HANDLER.save();
+                    String feedbackMessage = "Man spawning is now " + (config.enableManSpawning ? "ENABLED" : "DISABLED") + ".";
+                    context.getSource().sendFeedback(() -> Text.literal(feedbackMessage), true);
+                    return 1;
+                }))
             );
 
             registerTerrorCommands(dispatcher);

--- a/src/main/java/com/zen/the_fog/common/server/ModWorldEvents.java
+++ b/src/main/java/com/zen/the_fog/common/server/ModWorldEvents.java
@@ -185,6 +185,10 @@ public class ModWorldEvents implements ServerEntityEvents.Load, ServerWorldEvent
 
     @Override
     public void onEndTick(ServerWorld serverWorld) {
+        if (!Config.get().enableManSpawning) {
+            return; // Skip all man-related logic if spawning is disabled
+        }
+
         if (serverWorld.getPlayers(VALID_PLAYER_PREDICATE).isEmpty()) {
             return;
         }


### PR DESCRIPTION
- Added `enableManSpawning` boolean to Config.java (default true).
- ModWorldEvents.java now checks this config before attempting any Man spawning logic (including fake sounds).
- Added `/manfromthefog toggleManSpawning` command (op level 2) to dynamically enable/disable Man spawning and save the config.